### PR TITLE
change fkpredicate to use generic IRIs

### DIFF
--- a/javaTool/src/main/java/nl/um/cds/triplifier/rdf/DataFactory.java
+++ b/javaTool/src/main/java/nl/um/cds/triplifier/rdf/DataFactory.java
@@ -78,7 +78,6 @@ public class DataFactory extends RdfFactory{
         TupleQueryResult foreignKeys = ontologyFactory.getForeignKeys();
         while (foreignKeys.hasNext()) {
             BindingSet foreignKey = foreignKeys.next();
-            String fkPredicate = foreignKey.getValue("fkPredicate").stringValue();
             String columnClassUri = foreignKey.getValue("columnClassUri").stringValue();
             String targetClassUri = foreignKey.getValue("targetClassUri").stringValue();
 
@@ -87,7 +86,7 @@ public class DataFactory extends RdfFactory{
                     "        PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n" +
                     "\n" +
                     "        INSERT {\n" +
-                    "            ?sources <"+fkPredicate+"> ?targets.\n" +
+                    "            ?sources dbo:fk_refers_to ?targets.\n" +
                     "        } WHERE {\n" +
                     "\n" +
                     "            ?sources rdf:type <"+columnClassUri+">;\n" +

--- a/javaTool/src/main/java/nl/um/cds/triplifier/rdf/OntologyFactory.java
+++ b/javaTool/src/main/java/nl/um/cds/triplifier/rdf/OntologyFactory.java
@@ -100,6 +100,7 @@ public class OntologyFactory extends RdfFactory{
             //create target IRI to be sure it exists
             IRI targetIRI = this.addColumn(fKeyColumn.getPrimaryKeyTable(), fKeyColumn.getPrimaryKeyColumn());
             this.addStatement(sourceIRI, RDFS.SUBCLASSOF, DBO.FOREIGNKEY);
+            this.addStatement(sourceIRI, DBO.HAS_TARGET_COLUMN, targetIRI);
         }
     }
 
@@ -145,9 +146,9 @@ public class OntologyFactory extends RdfFactory{
         String sparqlQuery = "PREFIX dbo: <" + DBO.NAMESPACE + "> \n" +
                 "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#> \n" +
                 "SELECT * WHERE { \n" +
-                "            ?fkPredicate rdfs:subPropertyOf dbo:ColumnReference. \n" +
-                "            ?fkPredicate rdfs:domain ?columnClassUri. \n" +
-                "            ?fkPredicate rdfs:range ?targetClassUri. }";
+                "            ?columnClassUri rdfs:subClassOf dbo:ForeignKey. \n" +
+                "            ?columnClassUri dbo:has_target_column ?targetClassUri. \n" +
+                "}";
         logger.debug(sparqlQuery);
         TupleQuery tq = this.conn.prepareTupleQuery(sparqlQuery);
         TupleQueryResult result = tq.evaluate();

--- a/javaTool/src/main/java/nl/um/cds/triplifier/rdf/OntologyFactory.java
+++ b/javaTool/src/main/java/nl/um/cds/triplifier/rdf/OntologyFactory.java
@@ -96,21 +96,10 @@ public class OntologyFactory extends RdfFactory{
             IRI columnClassIRI = this.getClassForColumn(fKeyColumn.getForeignKeyTable(), fKeyColumn.getForeignKeyColumn());
             this.addStatement(columnClassIRI, RDFS.SUBCLASSOF, DBO.FOREIGNKEY);
 
-            String predicateName = "cell_refers_to";
-            String predicateLabel = "cell refers to";
-
-            IRI predicateIRI = vf.createIRI(this.baseIri, predicateName);
-            this.addStatement(predicateIRI, RDF.TYPE, OWL.OBJECTPROPERTY);
-            this.addStatement(predicateIRI, RDFS.LABEL, vf.createLiteral(predicateLabel));
-            this.addStatement(predicateIRI, RDFS.SUBPROPERTYOF, DBO.COLUMNREFERENCE);
-
             IRI sourceIRI = this.addColumn(fKeyColumn.getForeignKeyTable(), fKeyColumn.getForeignKeyColumn());
             //create target IRI to be sure it exists
             IRI targetIRI = this.addColumn(fKeyColumn.getPrimaryKeyTable(), fKeyColumn.getPrimaryKeyColumn());
             this.addStatement(sourceIRI, RDFS.SUBCLASSOF, DBO.FOREIGNKEY);
-
-            this.addStatement(predicateIRI, RDFS.DOMAIN, sourceIRI);
-            this.addStatement(predicateIRI, RDFS.RANGE, targetIRI);
         }
     }
 

--- a/javaTool/src/main/java/nl/um/cds/triplifier/rdf/OntologyFactory.java
+++ b/javaTool/src/main/java/nl/um/cds/triplifier/rdf/OntologyFactory.java
@@ -96,8 +96,8 @@ public class OntologyFactory extends RdfFactory{
             IRI columnClassIRI = this.getClassForColumn(fKeyColumn.getForeignKeyTable(), fKeyColumn.getForeignKeyColumn());
             this.addStatement(columnClassIRI, RDFS.SUBCLASSOF, DBO.FOREIGNKEY);
 
-            String predicateName = fKeyColumn.getForeignKeyTable() + "_" + fKeyColumn.getForeignKeyColumn() + "_refersTo_" + fKeyColumn.getPrimaryKeyTable() + "_" + fKeyColumn.getPrimaryKeyColumn();
-            String predicateLabel = fKeyColumn.getForeignKeyTable() + "." + fKeyColumn.getForeignKeyColumn() + " refers to " + fKeyColumn.getPrimaryKeyTable() + "." + fKeyColumn.getPrimaryKeyColumn();
+            String predicateName = "cell_refers_to";
+            String predicateLabel = "cell refers to";
 
             IRI predicateIRI = vf.createIRI(this.baseIri, predicateName);
             this.addStatement(predicateIRI, RDF.TYPE, OWL.OBJECTPROPERTY);

--- a/javaTool/src/main/java/nl/um/cds/triplifier/rdf/ontology/DBO.java
+++ b/javaTool/src/main/java/nl/um/cds/triplifier/rdf/ontology/DBO.java
@@ -20,6 +20,7 @@ public class DBO {
     public static final IRI HAS_CELL = SimpleValueFactory.getInstance().createIRI(NAMESPACE, "has_cell");
     public static final IRI HAS_UNIT = SimpleValueFactory.getInstance().createIRI(NAMESPACE, "has_unit");
     public static final IRI COLUMNREFERENCE = SimpleValueFactory.getInstance().createIRI(NAMESPACE, "ColumnReference");
+    public static final IRI CELL_REFERS_TO = SimpleValueFactory.getInstance().createIRI(NAMESPACE, "cell_refers_to");
 
     public static final IRI TABLE = SimpleValueFactory.getInstance().createIRI(NAMESPACE, "table");
     public static final IRI CATALOG = SimpleValueFactory.getInstance().createIRI(NAMESPACE, "catalog");
@@ -52,6 +53,10 @@ public class DBO {
         conn.add(COLUMNREFERENCE, RDF.TYPE, OWL.OBJECTPROPERTY);
         conn.add(COLUMNREFERENCE, RDFS.DOMAIN, DATABASECOLUMN);
         conn.add(COLUMNREFERENCE, RDFS.RANGE, DATABASECOLUMN);
+
+        conn.add(CELL_REFERS_TO, RDF.TYPE, OWL.OBJECTPROPERTY);
+        conn.add(CELL_REFERS_TO, RDFS.LABEL, SimpleValueFactory.getInstance().createLiteral("cell refers to"));
+        conn.add(CELL_REFERS_TO, RDFS.SUBPROPERTYOF, DBO.COLUMNREFERENCE);
 
         conn.add(TABLE, RDF.TYPE, OWL.ANNOTATIONPROPERTY);
         conn.add(TABLE, RDFS.RANGE, DATABASETABLE);

--- a/javaTool/src/main/java/nl/um/cds/triplifier/rdf/ontology/DBO.java
+++ b/javaTool/src/main/java/nl/um/cds/triplifier/rdf/ontology/DBO.java
@@ -19,8 +19,9 @@ public class DBO {
     public static final IRI HAS_VALUE = SimpleValueFactory.getInstance().createIRI(NAMESPACE, "has_value");
     public static final IRI HAS_CELL = SimpleValueFactory.getInstance().createIRI(NAMESPACE, "has_cell");
     public static final IRI HAS_UNIT = SimpleValueFactory.getInstance().createIRI(NAMESPACE, "has_unit");
-    public static final IRI COLUMNREFERENCE = SimpleValueFactory.getInstance().createIRI(NAMESPACE, "ColumnReference");
-    public static final IRI CELL_REFERS_TO = SimpleValueFactory.getInstance().createIRI(NAMESPACE, "cell_refers_to");
+    // public static final IRI COLUMNREFERENCE = SimpleValueFactory.getInstance().createIRI(NAMESPACE, "ColumnReference");
+    public static final IRI HAS_TARGET_COLUMN = SimpleValueFactory.getInstance().createIRI(NAMESPACE, "has_target_column");
+    public static final IRI FK_REFERS_TO = SimpleValueFactory.getInstance().createIRI(NAMESPACE, "fk_refers_to");
 
     public static final IRI TABLE = SimpleValueFactory.getInstance().createIRI(NAMESPACE, "table");
     public static final IRI CATALOG = SimpleValueFactory.getInstance().createIRI(NAMESPACE, "catalog");
@@ -50,13 +51,13 @@ public class DBO {
         conn.add(HAS_UNIT, RDF.TYPE, OWL.ANNOTATIONPROPERTY);
         conn.add(HAS_UNIT, RDFS.DOMAIN, DATABASECOLUMN);
 
-        conn.add(COLUMNREFERENCE, RDF.TYPE, OWL.OBJECTPROPERTY);
-        conn.add(COLUMNREFERENCE, RDFS.DOMAIN, DATABASECOLUMN);
-        conn.add(COLUMNREFERENCE, RDFS.RANGE, DATABASECOLUMN);
+        conn.add(HAS_TARGET_COLUMN, RDF.TYPE, OWL.ANNOTATEDPROPERTY);
+        conn.add(HAS_TARGET_COLUMN, RDFS.DOMAIN, DATABASECOLUMN);
 
-        conn.add(CELL_REFERS_TO, RDF.TYPE, OWL.OBJECTPROPERTY);
-        conn.add(CELL_REFERS_TO, RDFS.LABEL, SimpleValueFactory.getInstance().createLiteral("cell refers to"));
-        conn.add(CELL_REFERS_TO, RDFS.SUBPROPERTYOF, DBO.COLUMNREFERENCE);
+        conn.add(FK_REFERS_TO, RDF.TYPE, OWL.OBJECTPROPERTY);
+        conn.add(FK_REFERS_TO, RDFS.LABEL, SimpleValueFactory.getInstance().createLiteral("foreign key refers to"));
+        conn.add(FK_REFERS_TO, RDFS.DOMAIN, DATABASECOLUMN);
+        conn.add(FK_REFERS_TO, RDFS.RANGE, PRIMARYKEY);
 
         conn.add(TABLE, RDF.TYPE, OWL.ANNOTATIONPROPERTY);
         conn.add(TABLE, RDFS.RANGE, DATABASETABLE);


### PR DESCRIPTION
Updated OntologyFactory to use generic predicate naming and labeling for handling foreign key relationships, in place of using table and column names.